### PR TITLE
Add JavaFX quiz front-end

### DIFF
--- a/src/main/java/com/example/javafx_backend_test/Main.java
+++ b/src/main/java/com/example/javafx_backend_test/Main.java
@@ -2,6 +2,6 @@ package com.example.javafx_backend_test;
 
 public class Main {
     public static void main(String[] args) {
-        quizGenerator.main(args);
+        QuizApp.main(args);
     }
 }

--- a/src/main/java/com/example/javafx_backend_test/QuizApp.java
+++ b/src/main/java/com/example/javafx_backend_test/QuizApp.java
@@ -1,0 +1,84 @@
+package com.example.javafx_backend_test;
+
+import javafx.application.Application;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Simple JavaFX front end that drives the quizGenerator.
+ * Displays each question's equation as an image rendered from its LaTeX URL,
+ * accepts user answers, checks them, and tracks the score.
+ */
+public class QuizApp extends Application {
+
+    private quizGenerator engine;
+    private ImageView questionView;
+    private TextField answerField;
+    private Label scoreLabel;
+    private Button checkButton;
+
+    @Override
+    public void start(Stage stage) {
+        engine = new quizGenerator(10);
+        questionView = new ImageView();
+        answerField = new TextField();
+        checkButton = new Button("Check Answer");
+        scoreLabel = new Label("Score: 0/0");
+
+        checkButton.setOnAction(e -> handleCheck());
+
+        VBox root = new VBox(15, questionView, answerField, checkButton, scoreLabel);
+        root.setAlignment(Pos.CENTER);
+        root.setPadding(new Insets(20));
+
+        stage.setTitle("Algebra Quiz");
+        stage.setScene(new Scene(root, 500, 400));
+        stage.show();
+
+        loadNextQuestion();
+    }
+
+    private void handleCheck() {
+        var q = engine.getCurrentQuestion();
+        if (q == null) {
+            return;
+        }
+        engine.submitAnswer(answerField.getText());
+        scoreLabel.setText("Score: " + engine.getScoreKeeper().getCorrect() + "/" + engine.getScoreKeeper().getAttempted());
+        if (engine.hasNextQuestion()) {
+            loadNextQuestion();
+            answerField.clear();
+        } else {
+            checkButton.setDisable(true);
+            answerField.setDisable(true);
+        }
+    }
+
+    private void loadNextQuestion() {
+        var q = engine.nextQuestion();
+        String url = buildLatexUrl(q.equationLatex);
+        questionView.setImage(new Image(url, true));
+    }
+
+    private static String buildLatexUrl(String latex) {
+        String fullLatex = "\\dpi{200}\\bg{white} \\displaystyle " + latex;
+        String encoded = URLEncoder.encode(fullLatex, StandardCharsets.UTF_8).replace("+", "%20");
+        return "https://latex.codecogs.com/png.latex?" + encoded;
+    }
+
+    public static void main(String[] args) {
+        launch();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce a simple JavaFX application that runs the 10-question quiz, renders equations via CodeCogs URLs, accepts answers, and tracks score.
- Update `Main` to launch the new QuizApp front-end.

## Testing
- `mvn -q test` *(fails: Network is unreachable when resolving Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b5bd1ac08321ba462a06235dfc3a